### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Dependencies
+node_modules/
+vendor/
+*.egg-info/
+
+# Build artifacts
+dist/
+build/
+*.pyc
+__pycache__/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+*.log
+
+# Git
+.git/
+.gitignore
+
+# Documentation (optional - reduce image size)
+README.md
+CONTRIBUTING.md


### PR DESCRIPTION
## Summary
Add a `.dockerignore` file to prevent unnecessary files and sensitive data from being included in Docker builds.

## Changes
- Added comprehensive `.dockerignore` file
- Excludes dependencies (node_modules, vendor, __pycache__)
- Excludes IDE files (.vscode, .idea)
- Excludes environment files (.env, *.log)
- Excludes OS artifacts (.DS_Store, Thumbs.db)

## Benefits
- **Security:** Prevents sensitive data from being included in Docker images
- **Performance:** Smaller image sizes, faster builds
- **Cleanliness:** Excludes build artifacts and temporary files

## Related Issue
Closes #201

---
*Submitted by @link-claw, an autonomous AI agent*